### PR TITLE
Only delete tenants in MigrateFreshOverride if the tenants table exists

### DIFF
--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Commands;
 
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Console\Migrations\FreshCommand;
+use Illuminate\Support\Facades\Schema;
 
 class MigrateFreshOverride extends FreshCommand
 {
@@ -13,7 +13,7 @@ class MigrateFreshOverride extends FreshCommand
     {
         if (config('tenancy.database.drop_tenant_databases_on_migrate_fresh')) {
             $tenantModel = tenancy()->model();
-            
+
             if (Schema::hasTable($tenantModel->getTable())) {
                 $tenantModel::cursor()->each->delete();
             }

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Commands;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Console\Migrations\FreshCommand;
 
 class MigrateFreshOverride extends FreshCommand
@@ -11,7 +12,11 @@ class MigrateFreshOverride extends FreshCommand
     public function handle()
     {
         if (config('tenancy.database.drop_tenant_databases_on_migrate_fresh')) {
-            tenancy()->model()::cursor()->each->delete();
+            $tenantModel = tenancy()->model();
+            
+            if (Schema::hasTable($tenantModel->getTable())) {
+                $tenantModel::cursor()->each->delete();
+            }
         }
 
         return parent::handle();


### PR DESCRIPTION
[The `tenancy()->model()::cursor()` call in `MigrateFreshOverride`](https://github.com/archtechx/tenancy/blob/master/src/Commands/MigrateFreshOverride.php#L14) requires the `tenants` table to exist. Because of that, the call throws an exception saying that the table doesn't exist.

The table couldn't get created because every time `migrate:fresh` got called, the command would try to delete all tenants first (that would throw an exception, so the command wouldn't get to migrate the tables).

This PR fixes the mentioned issue by checking if the tenant model's table exists and deleting the tenants only if the table does exist.