### PR TITLE
[4.x] Add Laravel 11 and PHP 8.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,14 @@ jobs:
     strategy:
       matrix:
         include:
+        - laravel: "^11.0"
+          php: "8.3"
         - laravel: "^12.0"
           php: "8.4"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Composer dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ jobs:
     name: Validate code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check for todo0
       run: '! grep -r "todo0" --exclude-dir=workflows .'
       if: always()

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "ext-json": "*",
-        "illuminate/support": "^12.0",
+        "illuminate/support": "^11.0 || ^12.0",
         "laravel/tinker": "^2.0",
         "facade/ignition-contracts": "^1.0.2",
         "spatie/ignition": "^1.4",
@@ -29,8 +29,8 @@
         "laravel/prompts": "0.*"
     },
     "require-dev": {
-        "laravel/framework": "^12.0",
-        "orchestra/testbench": "^10.0",
+        "laravel/framework": "^11.0 || ^12.0",
+        "orchestra/testbench": "^9.0 || ^10.0",
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "doctrine/dbal": "^3.6.0",
         "spatie/valuestore": "^1.2.5",


### PR DESCRIPTION
Added Laravel 11 and PHP 8.3 support. Laravel 11 is still supported to [March 12th, 2026](https://laravel.com/docs/12.x/releases) and PHP 8.3 is still supported to [31 Dec 2027](https://www.php.net/supported-versions.php). I also think that going from php 8.0 to php 8.4 as a minimum is too big of a leap.