### PR TITLE
migrate-fresh can show output with verbose

### DIFF
--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Stancl\Tenancy\Concerns\DealsWithMigrations;
 use Stancl\Tenancy\Concerns\HasATenantsOption;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 
 final class MigrateFresh extends Command
 {
@@ -46,11 +47,12 @@ final class MigrateFresh extends Command
             ]));
 
             $this->info('Migrating.');
-            $this->call('tenants:migrate', [
+            $output = $this->getOutput()->isVerbose() ? $this->output : new NullOutput;
+            $this->runCommand('tenants:migrate', [
                 '--tenants' => [$tenant->getTenantKey()],
                 '--step' => $this->option('step'),
                 '--force' => true,
-            ]);
+            ], $output);
         });
 
         $this->info('Done.');

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -46,7 +46,7 @@ final class MigrateFresh extends Command
             ]));
 
             $this->info('Migrating.');
-            $this->callSilent('tenants:migrate', [
+            $this->call('tenants:migrate', [
                 '--tenants' => [$tenant->getTenantKey()],
                 '--step' => $this->option('step'),
                 '--force' => true,


### PR DESCRIPTION
I would be very happy if migrate:fresh don't run silent by default. 
Silent is still possible with the silent option