### PR TITLE
[4.x] Add `--force` option to `tenants:migrate-fresh`

### DIFF
--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Commands;
 
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Console\Migrations\BaseCommand;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\LazyCollection;
@@ -17,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface as OI;
 
 class MigrateFresh extends BaseCommand
 {
-    use HasTenantOptions, DealsWithMigrations, ParallelCommand;
+    use HasTenantOptions, DealsWithMigrations, ParallelCommand, ConfirmableTrait;
 
     protected $description = 'Drop all tables and re-run all migrations for tenant(s)';
 
@@ -27,6 +28,7 @@ class MigrateFresh extends BaseCommand
 
         $this->addOption('drop-views', null, InputOption::VALUE_NONE, 'Drop views along with tenant tables.', null);
         $this->addOption('step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually.');
+        $this->addOption('force', null, InputOption::VALUE_NONE, 'Force the command to run when in production.', null);
         $this->addProcessesOption();
 
         $this->setName('tenants:migrate-fresh');
@@ -34,6 +36,10 @@ class MigrateFresh extends BaseCommand
 
     public function handle(): int
     {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
         $success = true;
 
         if ($this->getProcesses() > 1) {

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -311,6 +311,21 @@ test('migrate fresh command works', function () {
     expect(DB::table('users')->exists())->toBeFalse();
 });
 
+test('migrate fresh command respects force option in production', function () {
+    // Set environment to production
+    app()->detectEnvironment(fn() => 'production');
+
+    Tenant::create();
+
+    // Without --force in production, command should prompt for confirmation
+    pest()->artisan('tenants:migrate-fresh')
+        ->expectsConfirmation('Are you sure you want to run this command?');
+
+    // With --force, command should succeed without prompting
+    pest()->artisan('tenants:migrate-fresh', ['--force' => true])
+        ->assertSuccessful();
+});
+
 test('run command with array of tenants works', function () {
     $tenantId1 = Tenant::create()->getTenantKey();
     $tenantId2 = Tenant::create()->getTenantKey();


### PR DESCRIPTION
This PR adds the `--force` option to the `tenants:migrate-fresh` command. Now, when you run `tenants:migrate-fresh` in production, you get prompted for confirmation. If you run `tenants:migrate-fresh --force`, the command will run without prompting for confirmation.

resolves #1194