### PR TITLE
[3.x] [Backport] Refactor forgetDisks to handle scoped disks

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -99,8 +99,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         foreach ($this->app['config']['filesystems.disks'] as $name => $disk) {
             if (isset($disk['driver'], $disk['disk'])
                 && $disk['driver'] === 'scoped'
-                && in_array($disk['disk'], $tenantDisks, true)
-                && ! in_array($name, $scopedDisks, true)) {
+                && in_array($disk['disk'], $tenantDisks, true)) {
                 $scopedDisks[] = $name;
             }
         }


### PR DESCRIPTION
Refactor disk management by introducing forgetDisks method to handle tenant and scoped disks more efficiently.

This is a backport of #1402 and fixes #1401 