### PR TITLE
[4.x] Pending tenants: Add getPendingAttributes()

### DIFF
--- a/tests/Etc/Tenant.php
+++ b/tests/Etc/Tenant.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests\Etc;
 
+use Closure;
 use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 use Stancl\Tenancy\Database\Concerns\HasDatabase;
 use Stancl\Tenancy\Database\Concerns\HasDomains;
@@ -16,11 +17,17 @@ use Stancl\Tenancy\Database\Models;
 class Tenant extends Models\Tenant implements TenantWithDatabase
 {
     public static array $extraCustomColumns = [];
+    public static ?Closure $getPendingAttributesUsing = null;
 
     use HasDatabase, HasDomains, HasPending;
 
     public static function getCustomColumns(): array
     {
         return array_merge(parent::getCustomColumns(), static::$extraCustomColumns);
+    }
+
+    public static function getPendingAttributes(array $attributes): array
+    {
+        return static::$getPendingAttributesUsing ? (static::$getPendingAttributesUsing)($attributes) : [];
     }
 }


### PR DESCRIPTION
This method lets the user specify default values for custom non-nullable columns. The primary use case is when the tenants table has a column like 'slug' and createPending() is called with no value for 'slug'. This would produce an exception due to the column having no default value.

Here, getPendingAttributes() can set an initial dummy slug (like a randomly generated string) before it's overwritten during a pull.

getPendingAttributes() accepts an $attributes array which corresponds to the attributes passed to createPending(). The array returned from getPendingAttributes() is ultimately merged with $attributes, so the user doesn't need to use the $attributes value in getPendingAttributes(), however it serves to provide more context when the pending attributes might be dependent on $attributes and therefore derived from the $attributes actually being used.

Also fixed the `finally` branch in createPending() as it was potentially referencing the $tenant variable before it was initialized.