### PR TITLE
[4.x] Config: scope_sessions = true only with supported drivers, always throw

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -313,7 +313,7 @@ return [
          *
          * Note: This will implicitly add your configured session store to the list of prefixed stores above.
          */
-        'scope_sessions' => true,
+        'scope_sessions' => in_array(env('SESSION_DRIVER'), ['redis', 'memcached', 'dynamodb', 'apc'], true),
 
         'tag_base' => 'tenant', // This tag_base, followed by the tenant_id, will form a tag that will be applied on each cache call.
     ],

--- a/src/Bootstrappers/CacheTenancyBootstrapper.php
+++ b/src/Bootstrappers/CacheTenancyBootstrapper.php
@@ -102,14 +102,7 @@ class CacheTenancyBootstrapper implements TenancyBootstrapper
         if ($this->config->get('tenancy.cache.scope_sessions', true)) {
             // These are the only cache driven session backends (see Laravel's config/session.php)
             if (! in_array($this->config->get('session.driver'), ['redis', 'memcached', 'dynamodb', 'apc'], true)) {
-                if (app()->environment('production')) {
-                    // We only throw this exception in prod to make configuration a little easier. Developers
-                    // may have scope_sessions set to true while using different session drivers e.g. in tests.
-                    // Previously we just silently ignored this, however since session scoping is of high importance
-                    // in production, we make sure to notify the developer, by throwing an exception, that session
-                    // scoping isn't happening as expected/configured due to an incompatible session driver.
-                    throw new Exception('Session driver [' . $this->config->get('session.driver') . '] cannot be scoped by tenancy.cache.scope_sessions');
-                }
+                throw new Exception('Session driver [' . $this->config->get('session.driver') . '] cannot be scoped by tenancy.cache.scope_sessions');
             } else {
                 // Scoping sessions using this bootstrapper implicitly adds the session store to $names
                 $names[] = $this->getSessionCacheStoreName();


### PR DESCRIPTION
With the previous implementation, many users would use the default config that enables scope_sessions. They would then deploy the app to production and get the exception there since they use the `database` session driver which is scoped by a different mechanism.

The idea behind throwing the exception only in prod was to make it easy to use different setups locally without getting annoying exceptions, while notifying users that a security feature they enabled isn't running in production.

However, a better way of doing this is to just throw the exception consistently in all setups and use a sane default for enabling the scope_sessions setting based on the SESSION_DRIVER env var.

Users are always encouraged to read the session scoping docs to make sure their session scoping configuration makes sense for their specific setup, but this is a good balance for providing solid security out of the box for most setups without requiring users to configure things manually.

---

While this is not a breaking change, existing applications should update their config file in line with this diff to avoid getting the informative exception locally unnecessarily.
```sh
curl -s https://patch-diff.githubusercontent.com/raw/archtechx/tenancy/pull/1412.diff \
    | head -n13 \
    | sed 's/assets\/config.php/config\/tenancy.php/g' \
    | git apply
```