### PR TITLE
Fix incorrect subdomain identification

### DIFF
--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -56,9 +56,19 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
         return $tenant;
     }
 
-    public static function isSubdomain(string $domain): bool
+    protected function isSubdomain(string $hostname): bool
     {
-        return Str::endsWith($domain, config('tenancy.identification.central_domains'));
+        foreach (config('tenancy.central_domains') as $domain) {
+            if ($hostname === $domain) {
+                return false;
+            }
+
+            if (Str::endsWith($hostname, '.' . $domain)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function resolved(Tenant $tenant, mixed ...$args): void

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -56,9 +56,12 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
         return $tenant;
     }
 
-    public static function isSubdomain(string $hostname): bool
+    protected function isSubdomain(string $hostname): bool
     {
-        foreach (config('tenancy.central_domains') as $domain) {
+        $centralDomains = Arr::wrap(config('tenancy.central_domains'));
+
+        foreach ($centralDomains as $domain) {
+
             if ($hostname === $domain) {
                 return false;
             }

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -56,7 +56,7 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
         return $tenant;
     }
 
-    protected function isSubdomain(string $hostname): bool
+    public static function isSubdomain(string $hostname): bool
     {
         foreach (config('tenancy.central_domains') as $domain) {
             if ($hostname === $domain) {


### PR DESCRIPTION
After reviewing issue #1398 the code for subdomain initialization missed few cases.

For example, `test1-tms.test` is not a subdomain, but original `Str::endsWith` will always return true and identify it as subdomain.

If this solution is ok, I will add test cases.



