### PR TITLE
[4.x] Add more relation type annotations

### DIFF
--- a/src/Database/Concerns/BelongsToTenant.php
+++ b/src/Database/Concerns/BelongsToTenant.php
@@ -17,6 +17,9 @@ trait BelongsToTenant
 {
     use FillsCurrentTenant;
 
+    /**
+     * @return BelongsTo<\Stancl\Tenancy\Contracts\Tenant, $this>
+     */
     public function tenant(): BelongsTo
     {
         return $this->belongsTo(config('tenancy.models.tenant'), Tenancy::tenantKeyColumn());

--- a/src/Database/Concerns/BelongsToTenant.php
+++ b/src/Database/Concerns/BelongsToTenant.php
@@ -18,7 +18,7 @@ trait BelongsToTenant
     use FillsCurrentTenant;
 
     /**
-     * @return BelongsTo<\Stancl\Tenancy\Contracts\Tenant, $this>
+     * @return BelongsTo<\Illuminate\Database\Eloquent\Model&\Stancl\Tenancy\Contracts\Tenant, $this>
      */
     public function tenant(): BelongsTo
     {

--- a/src/Database/Concerns/HasDomains.php
+++ b/src/Database/Concerns/HasDomains.php
@@ -14,6 +14,9 @@ use Stancl\Tenancy\Tenancy;
  */
 trait HasDomains
 {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Domain, $this>
+     */
     public function domains()
     {
         return $this->hasMany(config('tenancy.models.domain'), Tenancy::tenantKeyColumn());

--- a/src/Database/Concerns/HasDomains.php
+++ b/src/Database/Concerns/HasDomains.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Database\Concerns;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Tenancy;
 
@@ -15,9 +16,9 @@ use Stancl\Tenancy\Tenancy;
 trait HasDomains
 {
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Domain, $this>
+     * @return HasMany<\Illuminate\Database\Eloquent\Model&\Stancl\Tenancy\Contracts\Domain, $this>
      */
-    public function domains()
+    public function domains(): HasMany
     {
         return $this->hasMany(config('tenancy.models.domain'), Tenancy::tenantKeyColumn());
     }

--- a/src/ResourceSyncing/ResourceSyncing.php
+++ b/src/ResourceSyncing/ResourceSyncing.php
@@ -105,6 +105,9 @@ trait ResourceSyncing
         return true;
     }
 
+    /**
+     * @return BelongsToMany<TenantWithDatabase, $this>
+     */
     public function tenants(): BelongsToMany
     {
         return $this->morphToMany(config('tenancy.models.tenant'), 'tenant_resources', 'tenant_resources', 'resource_global_id', 'tenant_id', $this->getGlobalIdentifierKeyName())

--- a/src/ResourceSyncing/ResourceSyncing.php
+++ b/src/ResourceSyncing/ResourceSyncing.php
@@ -106,7 +106,7 @@ trait ResourceSyncing
     }
 
     /**
-     * @return BelongsToMany<TenantWithDatabase, $this>
+     * @return BelongsToMany<\Stancl\Tenancy\Database\Contracts\TenantWithDatabase, $this>
      */
     public function tenants(): BelongsToMany
     {

--- a/src/ResourceSyncing/ResourceSyncing.php
+++ b/src/ResourceSyncing/ResourceSyncing.php
@@ -106,7 +106,7 @@ trait ResourceSyncing
     }
 
     /**
-     * @return BelongsToMany<\Stancl\Tenancy\Database\Contracts\TenantWithDatabase, $this>
+     * @return BelongsToMany<\Illuminate\Database\Eloquent\Model&\Stancl\Tenancy\Database\Contracts\TenantWithDatabase, $this>
      */
     public function tenants(): BelongsToMany
     {


### PR DESCRIPTION
This pull request adds improved PHPDoc type annotations to several Eloquent relationship methods, enhancing static analysis and developer experience. These changes clarify the expected return types for relationships, making the codebase easier to understand and work with.

Relationship method type annotations:

* Added a detailed return type annotation to the `tenant` method in the `BelongsToTenant` trait, specifying the related model and the current class.
* Added a detailed return type annotation to the `domains` method in the `HasDomains` trait, specifying the related model and the current class.
* Added a detailed return type annotation to the `tenants` method in the `ResourceSyncing` class, specifying the related model and the current class.