### PR TITLE
[4.x] Fix URL override example in TenancyServiceProvider stub

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -167,6 +167,10 @@ class TenancyServiceProvider extends ServiceProvider
         //         ? $tenant->domain
         //         : $tenant->domains->first()->domain;
         //
+        //     if (is_null($tenantDomain)) {
+        //         return $originalRootUrl;
+        //     }
+        //
         //     $scheme = str($originalRootUrl)->before('://');
         //
         //     if (str_contains($tenantDomain, '.')) {


### PR DESCRIPTION
This PR fixes the URL override example in TenancyServiceProvider stub (the commented `overrideUrlInTenantContext()` segment). If the tenant doesn't have any domain, set the root URL back to the original one.