### PR TITLE
[4.x] Update Pest to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "doctrine/dbal": "^3.6.0",
         "spatie/valuestore": "^1.2.5",
-        "pestphp/pest": "^3.0",
+        "pestphp/pest": "^4.0",
         "larastan/larastan": "^3.0",
         "league/flysystem-path-prefixing": "^3.0"
     },


### PR DESCRIPTION
# Why?
I ran into the following error while trying to run composer install against the package `composer.json`

<details>

<summary>orchestra/testbench-core 10.x-dev conflicts with phpunit/phpunit <10.5.35|>=11.0.0 <11.5.3|12.0.0|>=12.6.0</summary>

```
    Problem 1
    - Root composer.json requires orchestra/testbench ^10.0 -> satisfiable by orchestra/testbench[v10.0.0, ..., 10.x-dev].
    - Root composer.json requires pestphp/pest ^3.0 -> satisfiable by pestphp/pest[v3.0.0, ..., 3.x-dev].
    - orchestra/testbench 10.x-dev requires orchestra/testbench-core ^10.9.0 -> satisfiable by orchestra/testbench-core[10.x-dev].
    - orchestra/testbench-core 10.x-dev conflicts with phpunit/phpunit <10.5.35|>=11.0.0 <11.5.3|12.0.0|>=12.6.0.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.46.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.40.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.39.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.34.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.33.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.29.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.28.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.26.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.23.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.20.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.18.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.15.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.14.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.13.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.12.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.11.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.10.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.8.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.3.
    - pestphp/pest v3.0.0 conflicts with phpunit/phpunit 11.5.x-dev.
    - pestphp/pest v3.0.0 requires phpunit/phpunit ^11.3.4 -> satisfiable by phpunit/phpunit[11.3.4, ..., 11.5.x-dev].
    - Conclusion: don't install pestphp/pest v3.0.1 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.0.6 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.0.8 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.1.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.2.5 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.3.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.3.2 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.4.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.4.1 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.5.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.5.1 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.6.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.7.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.7.1 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.7.2 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.7.3 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.7.4 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.7.5 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.8.0 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.8.2 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.8.3 (conflict analysis result)
    - Conclusion: don't install pestphp/pest v3.8.4 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.0.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.1.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.2.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.2.1 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.2.2 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.3.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.4.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.5.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.6.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.7.0 (conflict analysis result)
    - Conclusion: don't install orchestra/testbench v10.8.0 (conflict analysis result)
```

</details>

Since Pest v4 is api compatible with v3, this PR should not have any BC.

Thanks for the great work on this package 👏🏽💪

