### PR TITLE
Change tenants.id column type from string to uuid

### DIFF
--- a/assets/migrations/2019_09_15_000010_create_tenants_table.php
+++ b/assets/migrations/2019_09_15_000010_create_tenants_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('tenants', function (Blueprint $table) {
-            $table->string('id')->primary();
+            $table->uuid('id')->primary();
 
             // your custom columns may go here
 


### PR DESCRIPTION
This PR updates the tenants table migration by changing the primary key column type from string to uuid.

Before:
$table->string('id')->primary();

After:
$table->uuid('id')->primary();

This ensures proper UUID typing at the database level and aligns with Stancl Tenancy's recommended configuration.

https://laravel.com/docs/12.x/migrations#column-method-uuid