### PR TITLE
[4.x] Add Tenancy::reinitialize() method

### DIFF
--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -152,6 +152,26 @@ class Tenancy
         $this->initialized = false;
     }
 
+    /**
+     * End tenancy and initialize it again for the current tenant.
+     *
+     * This can be helpful when changing "dependencies" of bootstrappers such as
+     * attributes of the current tenant that are only read once, during bootstrap().
+     *
+     * If tenancy is not initialized, this method is a no-op.
+     */
+    public function reinitialize(): void
+    {
+        if ($this->tenant === null) {
+            return;
+        }
+
+        $tenant = $this->tenant;
+        $this->end();
+
+        $this->initialize($tenant);
+    }
+
     /** @return TenancyBootstrapper[] */
     public function getBootstrappers(): array
     {

--- a/tests/AutomaticModeTest.php
+++ b/tests/AutomaticModeTest.php
@@ -103,6 +103,33 @@ test('central helper doesnt change tenancy state when called in central context'
     expect(tenant())->toBeNull();
 });
 
+test('reinitialize method does nothing in the central context', function () {
+    expect(tenancy()->initialized)->toBe(false);
+    expect(fn () => tenancy()->reinitialize())->not()->toThrow(\Throwable::class);
+    expect(tenancy()->initialized)->toBe(false);
+});
+
+test('reinitialize method runs bootstrappers again for the current tenant', function () {
+    config(['tenancy.bootstrappers' => [
+        ReinitBootstrapper::class,
+    ]]);
+
+    tenancy()->initialize($tenant = Tenant::create(['reinit_bootstrapper_key' => 'foo']));
+
+    expect(tenant()->getKey())->toBe($tenant->getKey());
+    expect(app('tenancy_reinit_bootstrapper_key'))->toBe('foo');
+
+    $tenant->update(['reinit_bootstrapper_key' => 'bar']);
+
+    // Unchanged until we reinitialize...
+    expect(app('tenancy_reinit_bootstrapper_key'))->toBe('foo');
+
+    tenancy()->reinitialize();
+
+    expect(tenant()->getKey())->toBe($tenant->getKey());
+    expect(app('tenancy_reinit_bootstrapper_key'))->toBe('bar');
+});
+
 class MyBootstrapper implements TenancyBootstrapper
 {
     public function bootstrap(\Stancl\Tenancy\Contracts\Tenant $tenant): void
@@ -113,5 +140,18 @@ class MyBootstrapper implements TenancyBootstrapper
     public function revert(): void
     {
         app()->instance('tenancy_ended', true);
+    }
+}
+
+class ReinitBootstrapper implements TenancyBootstrapper
+{
+    public function bootstrap(\Stancl\Tenancy\Contracts\Tenant $tenant): void
+    {
+        app()->instance('tenancy_reinit_bootstrapper_key', $tenant->getAttribute('reinit_bootstrapper_key'));
+    }
+
+    public function revert(): void
+    {
+        app()->instance('tenancy_reinit_bootstrapper_key', null);
     }
 }


### PR DESCRIPTION
Some bootstrappers read attributes of the tenant during bootstrap() but don't respond to changes made to the tenant afterwards.

Therefore, when making changes to the tenant that'd affect the behavior of a bootstrapper, it's necessary to reinitialize tenancy (if it matters that changes are reflected immediately). This adds a convenience helper for that purpose.