### PR TITLE
[4.x] Prevent mkdir() race conditions in FilesystemTenancyBootstrapper

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Bootstrappers;
 
+use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Session\FileSessionHandler;
 use Illuminate\Support\Facades\Storage;
@@ -75,8 +76,13 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             : $this->originalStoragePath . '/framework/cache';
 
         if (! is_dir($path)) {
-            // Create tenant framework/cache directory if it does not exist
-            mkdir($path, 0750, true);
+            // Create tenant framework/cache directory if it does not exist.
+            // We ignore errors due to TOCTOU race conditions, instead we check for success below.
+            @mkdir($path, 0750, true);
+
+            if (! is_dir($path)) {
+                throw new Exception("Unable to create tenant storage directory [{$path}].");
+            }
         }
 
         if ($suffix === false) {
@@ -222,8 +228,13 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             : $this->originalStoragePath . '/framework/sessions';
 
         if (! is_dir($path)) {
-            // Create tenant framework/sessions directory if it does not exist
-            mkdir($path, 0750, true);
+            // Create tenant framework/sessions directory if it does not exist.
+            // We ignore errors due to TOCTOU race conditions, instead we check for success below.
+            @mkdir($path, 0750, true);
+
+            if (! is_dir($path)) {
+                throw new Exception("Unable to create tenant session directory [{$path}].");
+            }
         }
 
         $this->app['config']['session.files'] = $path;


### PR DESCRIPTION
Prevent mkdir() race conditions in FilesystemTenancyBootstrapper

This prevents race conditions that may occur if there are two concurrent
processes trying to create the storage path for the tenant. The
storagePath() method runs during bootstrap() which can easily happen
in two places at once. The race condition specifically occurs in between
the is_dir() check and the mkdir() call, the latter producing an
exception if the dir already exist. We simply ignore any error coming
out of mkdir() and then check for success separately.

We could omit that success check since failure is unlikely and would
only occur due to a server misconfiguration that would manifest itself
in other ways as well, but this way the simple TOC/TOU race condition
is prevented while other errors are still reported.

We apply the same change to the mkdir() in scopeSessions() as the logic
is similar.

Resolves #1452


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed spurious filesystem warnings during concurrent startup and added clearer failure reporting when required cache and session storage directories cannot be created, reducing noisy logs and improving reliability during application boot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->