### PR TITLE
Add count-based retry policy to all queued jobs in src/Jobs

### DIFF
--- a/src/Jobs/ClearPendingTenants.php
+++ b/src/Jobs/ClearPendingTenants.php
@@ -15,6 +15,10 @@ class ClearPendingTenants implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
+    public int $tries = 3;
+
+    public array $backoff = [30, 60, 120];
+
     public function handle(): void
     {
         Artisan::call(ClearPendingTenantsCommand::class);

--- a/src/Jobs/ClearPendingTenants.php
+++ b/src/Jobs/ClearPendingTenants.php
@@ -15,8 +15,10 @@ class ClearPendingTenants implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public function handle(): void

--- a/src/Jobs/CreateDatabase.php
+++ b/src/Jobs/CreateDatabase.php
@@ -21,8 +21,10 @@ class CreateDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public static bool $ignoreExisting = false;

--- a/src/Jobs/CreateDatabase.php
+++ b/src/Jobs/CreateDatabase.php
@@ -23,6 +23,8 @@ class CreateDatabase implements ShouldQueue
 
     public int $tries = 3;
 
+    public array $backoff = [30, 60, 120];
+
     public static bool $ignoreExisting = false;
 
     public function __construct(

--- a/src/Jobs/CreateDatabase.php
+++ b/src/Jobs/CreateDatabase.php
@@ -21,6 +21,8 @@ class CreateDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
     public static bool $ignoreExisting = false;
 
     public function __construct(

--- a/src/Jobs/CreatePendingTenants.php
+++ b/src/Jobs/CreatePendingTenants.php
@@ -15,6 +15,10 @@ class CreatePendingTenants implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
+    public int $tries = 3;
+
+    public array $backoff = [30, 60, 120];
+
     public function handle(): void
     {
         Artisan::call(CreatePendingTenantsCommand::class);

--- a/src/Jobs/CreatePendingTenants.php
+++ b/src/Jobs/CreatePendingTenants.php
@@ -15,8 +15,10 @@ class CreatePendingTenants implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public function handle(): void

--- a/src/Jobs/CreateStorageSymlinks.php
+++ b/src/Jobs/CreateStorageSymlinks.php
@@ -16,6 +16,10 @@ class CreateStorageSymlinks implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
+    public array $backoff = [30, 60, 120];
+
     public function __construct(
         public Tenant $tenant,
     ) {}

--- a/src/Jobs/CreateStorageSymlinks.php
+++ b/src/Jobs/CreateStorageSymlinks.php
@@ -16,8 +16,10 @@ class CreateStorageSymlinks implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public function __construct(

--- a/src/Jobs/DeleteDatabase.php
+++ b/src/Jobs/DeleteDatabase.php
@@ -20,6 +20,8 @@ class DeleteDatabase implements ShouldQueue
 
     public int $tries = 3;
 
+    public array $backoff = [30, 60, 120];
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}

--- a/src/Jobs/DeleteDatabase.php
+++ b/src/Jobs/DeleteDatabase.php
@@ -18,6 +18,8 @@ class DeleteDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}

--- a/src/Jobs/DeleteDatabase.php
+++ b/src/Jobs/DeleteDatabase.php
@@ -18,8 +18,10 @@ class DeleteDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public function __construct(

--- a/src/Jobs/MigrateDatabase.php
+++ b/src/Jobs/MigrateDatabase.php
@@ -17,8 +17,10 @@ class MigrateDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public function __construct(

--- a/src/Jobs/MigrateDatabase.php
+++ b/src/Jobs/MigrateDatabase.php
@@ -19,6 +19,8 @@ class MigrateDatabase implements ShouldQueue
 
     public int $tries = 3;
 
+    public array $backoff = [30, 60, 120];
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}

--- a/src/Jobs/MigrateDatabase.php
+++ b/src/Jobs/MigrateDatabase.php
@@ -17,6 +17,8 @@ class MigrateDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}

--- a/src/Jobs/RemoveStorageSymlinks.php
+++ b/src/Jobs/RemoveStorageSymlinks.php
@@ -16,6 +16,10 @@ class RemoveStorageSymlinks implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
+    public array $backoff = [30, 60, 120];
+
     public Tenant $tenant;
 
     /**

--- a/src/Jobs/RemoveStorageSymlinks.php
+++ b/src/Jobs/RemoveStorageSymlinks.php
@@ -16,8 +16,10 @@ class RemoveStorageSymlinks implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public Tenant $tenant;

--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -17,6 +17,8 @@ class SeedDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}

--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -19,6 +19,8 @@ class SeedDatabase implements ShouldQueue
 
     public int $tries = 3;
 
+    public array $backoff = [30, 60, 120];
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}

--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -17,8 +17,10 @@ class SeedDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /** The maximum number of times the job may be attempted. */
     public int $tries = 3;
 
+    /** Delay in seconds between retries. */
     public array $backoff = [30, 60, 120];
 
     public function __construct(


### PR DESCRIPTION
## What

Adds a count-based retry policy (`$tries = 3` + `$backoff = [30, 60, 120]`) to every `ShouldQueue` class in `src/Jobs/`. Eight files, 48 insertions across source + docblocks. No behavioural change for successful jobs, no scope touched outside `src/Jobs/`.

Covered:

| File | Existing config | Added |
|------|-----------------|-------|
| `CreateDatabase.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `MigrateDatabase.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `DeleteDatabase.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `SeedDatabase.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `ClearPendingTenants.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `CreatePendingTenants.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `CreateStorageSymlinks.php` | none | `$tries=3`, `$backoff=[30,60,120]` |
| `RemoveStorageSymlinks.php` | none | `$tries=3`, `$backoff=[30,60,120]` |

`DeleteDomains.php` is left alone (synchronous, not queued). `src/Listeners/QueueableListener.php` is an abstract base with no retry config, out of scope for this PR.

## Why

None of these jobs currently set `$tries`. Without it, the retry behaviour is whatever the operator configured on their worker:

- `php artisan queue:work` (no flag) — default is **1 attempt**. Job runs once, fails once, goes to `failed_jobs`.
- `php artisan queue:work --tries=0` — **unlimited retries**. This is the default on Laravel Vapor prior to vapor-core 2.4.1.
- `php artisan queue:work --tries=N` — whatever the operator set.

### Why 1 attempt is fragile, in a concrete scenario

Tenant provisioning dispatches `CreateDatabase`. The DB server has a 20-second blip — common during provider maintenance, failover events, or connection-pool exhaustion.

**Today (no `$tries` on the job, default worker = 1 attempt):**
1. Job fires, gets `SQLSTATE[HY000] [2002]` — DB unreachable
2. Job lands in `failed_jobs` immediately
3. Tenant exists in the parent table but has no database
4. Operator gets a ticket, manually retries

**With `$tries = 3` + `$backoff = [30, 60, 120]`:**
1. Job fires, fails (DB unreachable)
2. Waits 30 seconds
3. Retries. DB is back by now. Succeeds.
4. No operator intervention, no partial tenant

The first case is the default for anyone running `queue:work` straight. It's fine on the happy path. It's brittle under any transient failure of the DB or filesystem dependency — which is the common failure mode for these jobs.

### Why automatic retry and not "user can click again"?

None of these 8 jobs are directly dispatched from within the package — they're wired up by consumers as event-listener pipelines (typically via `stancl/jobpipeline`) or scheduled artisan commands. A tenant-signup flow fires a `TenantCreated` event which kicks off `CreateDatabase`, `MigrateDatabase`, and `SeedDatabase` as a queued pipeline. `ClearPendingTenants` and `CreatePendingTenants` are artisan commands intended for the Laravel scheduler. In no case does the user press a button labelled "retry this step" — if any job in the pipeline fails transiently, it lands in `failed_jobs` with no UI surface. The operator's first signal is a support email hours later: "my tenant doesn't work". Automatic retry turns a transient blip into a non-event before anyone notices.

### For operators on `--tries=0`

Same change caps unlimited retries at three. `DeleteDatabase` is the highest-severity job here: a DB outage mid-delete otherwise retries indefinitely, and replays after recovery can hit a database that's already partly deleted or contains data the tenant wanted preserved.

### Why `$backoff`

The default `$backoff` is 0 seconds. Without spacing, three retries fire back-to-back as fast as the worker can process them — three hammer blows to the resource that just failed. `[30, 60, 120]` gives real recovery time.

## Why `$tries + $backoff` and not `retryUntil()`

Laravel's Worker silently ignores `$tries` when `retryUntil()` is set on the job. The framework treats them as two mutually exclusive retry policies. See [Worker.php:612 on 13.x](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Queue/Worker.php#L612), introduced in [laravel/framework#35214](https://github.com/laravel/framework/pull/35214) for design intent.

None of the eight jobs touched here use `retryUntil()`, so a count-based `$tries + $backoff` policy is effective. Subclasses that want time-based retries later can override with `retryUntil()` and the `$tries` value here will be ignored (safe).

## Note on `retry_after`

The Laravel 13 skeleton sets `retry_after = 90` seconds across the `database`, `beanstalkd`, and `redis` connections. `$backoff[0] = 30` stays well under that for short jobs. `MigrateDatabase` on a large tenant could exceed 90s though — operators running long migrations should tune `retry_after` in `config/queue.php` to `max(job_duration, backoff_max) + buffer`.

## Local verification

- `php vendor/bin/phpstan analyse --memory-limit=1G` — clean on the branch at level 8 (250/250 paths, no errors)
- `php -l` on every touched file — no syntax errors
- `grep -r 'tries\|backoff\|retryUntil' src/` against upstream master — no existing retry config conflicts with the additions
- GitHub Actions on the branch: tests (^12.0) ✅, tests (^13.0) ✅, Validate code ✅, Code style ✅, Static analysis ✅, codecov/patch ✅, codecov/project ✅

## Context

Part of a wider audit of queue safety across Laravel packages. Full write-up with reproducible tests: https://joshsalway.com/laravel-queue-safety

Happy to adjust the number (the audit default is 3 tries with `[30, 60, 120]` backoff) if you'd prefer a different shape.