### PR TITLE
Fix tenant sync not triggering when pivot is created in queued jobs

### DIFF
--- a/src/Listeners/UpdateSyncedResource.php
+++ b/src/Listeners/UpdateSyncedResource.php
@@ -82,7 +82,7 @@ class UpdateSyncedResource extends QueueableListener
 
         return $centralModel->tenants->filter(function ($model) use ($currentTenantMapping) {
             // Remove the mapping for the current tenant.
-            return ! $currentTenantMapping($model);
+            return ! $model->wasRecentlyCreated || ! $currentTenantMapping($model);
         });
     }
 


### PR DESCRIPTION
When a tenant is attached to a synced resource (e.g., User) inside a queued job (`Events\TenantCreated::class`), the current filtering logic in updateResourceInCentralDatabaseAndGetTenants() may exclude that tenant from the update cycle. As a result, updateResourceInTenantDatabases() is not triggered for newly attached tenants.

This occurs because the existing filter unconditionally removes the current tenant mapping, even when the pivot record has just been created during the same execution.