### PR TITLE
[4.x] Fix chaining `withoutPending()` with `where()`

### DIFF
--- a/src/Database/Concerns/PendingScope.php
+++ b/src/Database/Concerns/PendingScope.php
@@ -58,9 +58,9 @@ class PendingScope implements Scope
     {
         $builder->macro('withoutPending', function (Builder $builder) {
             $builder->withoutGlobalScope(static::class)
-                ->where(function (Builder $builder) {
-                    $builder->whereNull($builder->getModel()->getColumnForQuery('pending_since'))
-                        ->orWhereNull($builder->getModel()->getDataColumn());
+                ->where(function (Builder $query) {
+                    $query->whereNull($query->getModel()->getColumnForQuery('pending_since'))
+                        ->orWhereNull($query->getModel()->getDataColumn());
                 });
 
             return $builder;

--- a/src/Database/Concerns/PendingScope.php
+++ b/src/Database/Concerns/PendingScope.php
@@ -58,8 +58,10 @@ class PendingScope implements Scope
     {
         $builder->macro('withoutPending', function (Builder $builder) {
             $builder->withoutGlobalScope(static::class)
-                ->whereNull($builder->getModel()->getColumnForQuery('pending_since'))
-                ->orWhereNull($builder->getModel()->getDataColumn());
+                ->where(function (Builder $builder) {
+                    $builder->whereNull($builder->getModel()->getColumnForQuery('pending_since'))
+                        ->orWhereNull($builder->getModel()->getDataColumn());
+                });
 
             return $builder;
         });

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -115,8 +115,14 @@ test('withoutPending chained with where clauses returns correct results', functi
     $tenant = Tenant::create();
     $pendingTenant = Tenant::createPending();
 
-    expect(Tenant::withoutPending()->where('id', $tenant->id)->first()->id)->toBe($tenant->id);
-    expect(Tenant::withoutPending()->where('id', 'nonexistent-id')->first())->toBeNull();
+    $foundTenant = Tenant::withoutPending()->where('id', $tenant->id)->first();
+    expect($foundTenant)->not()->toBeNull();
+
+    // The query returned the correct tenant
+    expect($foundTenant->id)->toBe($tenant->id);
+    // No tenant with this ID exists, the query returns null
+    expect(Tenant::withoutPending()->where('id', Str::random(8) . 'nonexistent-id')->first())->toBeNull();
+    // withoutPending() correctly excludes the pending tenant from the query
     expect(Tenant::withoutPending()->where('id', $pendingTenant->id)->first())->toBeNull();
 });
 

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -115,11 +115,8 @@ test('withoutPending chained with where clauses returns correct results', functi
     $tenant = Tenant::create();
     $pendingTenant = Tenant::createPending();
 
-    $foundTenant = Tenant::withoutPending()->where('id', $tenant->id)->first();
-    expect($foundTenant)->not()->toBeNull();
-
     // The query returned the correct tenant
-    expect($foundTenant->id)->toBe($tenant->id);
+    expect(Tenant::withoutPending()->where('id', $tenant->id)->first()->id)->toBe($tenant->id);
     // No tenant with this ID exists, the query returns null
     expect(Tenant::withoutPending()->where('id', Str::random(8) . 'nonexistent-id')->first())->toBeNull();
     // withoutPending() correctly excludes the pending tenant from the query

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -111,6 +111,15 @@ test('a new tenant gets created while pulling a pending tenant if the pending po
     expect(Tenant::withPending()->get()->count())->toBe(1); // All tenants
 });
 
+test('withoutPending chained with where clauses returns correct results', function() {
+    $tenant = Tenant::create();
+    $pendingTenant = Tenant::createPending();
+
+    expect(Tenant::withoutPending()->where('id', $tenant->id)->first()->id)->toBe($tenant->id);
+    expect(Tenant::withoutPending()->where('id', 'nonexistent-id')->first())->toBeNull();
+    expect(Tenant::withoutPending()->where('id', $pendingTenant->id)->first())->toBeNull();
+});
+
 test('pending tenants are included in all queries based on the include_in_queries config', function () {
     Tenant::createPending();
 

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -111,7 +111,7 @@ test('a new tenant gets created while pulling a pending tenant if the pending po
     expect(Tenant::withPending()->get()->count())->toBe(1); // All tenants
 });
 
-test('withoutPending chained with where clauses returns correct results', function() {
+test('withoutPending chained with where clauses returns correct results', function () {
     $tenant = Tenant::create();
     $pendingTenant = Tenant::createPending();
 


### PR DESCRIPTION
At the moment, `where()` cannot be used correctly while using `withoutPending()`. For example, if we have a single non-pending tenant in our DB (with ID  'foo'), queries like `Tenant::withoutPending()->where('id', 'nonexistent')->first()`will incorrectly return the non-pending tenant ('foo').

This is because `withoutPending()` does `$builder->whereNull('data->pending_since')->orWhereNull('data')`. These two aren't grouped, so  `withoutPending()->where('id', 'nonexistent')` basically translates to "WHERE data->pending_since IS NULL **OR (data IS NULL AND id = 'nonexistent')**".  So the query will include all tenants whose `pending_since` is null (= all non-pending tenants).

Grouping `->whereNull('data->pending_since')->orWhereNull('data')` in a closure passed to a separate `where()` fixes this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query grouping so pending records are consistently excluded when combined with other filters, preventing incorrect matches.

* **Tests**
  * Added automated tests verifying pending-item exclusion across query combinations, including lookups by specific IDs and non-existent records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->