### PR TITLE
[4.x] migrate-fresh: show migration output when verbose

### DIFF
--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -14,6 +14,7 @@ use Stancl\Tenancy\Concerns\ParallelCommand;
 use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 use Stancl\Tenancy\Database\Exceptions\TenantDatabaseDoesNotExistException;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface as OI;
 
 class MigrateFresh extends BaseCommand
@@ -72,11 +73,13 @@ class MigrateFresh extends BaseCommand
 
     protected function migrateTenant(TenantWithDatabase $tenant): bool
     {
-        return $this->callSilently('tenants:migrate', [
+        $output = $this->getOutput()->isVerbose() ? $this->output : new NullOutput;
+
+        return $this->runCommand('tenants:migrate', [
             '--tenants' => [$tenant->getTenantKey()],
             '--step' => $this->option('step'),
             '--force' => true,
-        ]) === 0;
+        ], $output) === 0;
     }
 
     protected function childHandle(mixed ...$args): bool

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -374,13 +374,18 @@ test('migrate fresh command only shows migration output when run with the verbos
     // so we cannot easily test commands without -v. To work around that, we temporarily
     // override $_ENV['SHELL_VERBOSITY'] immediately before executing the command. If this
     // ever stops working, try also overriding the value in $_SERVER and putenv().
-    $originalVerbosity = $_ENV['SHELL_VERBOSITY'] ?? 0;
+    $emptySentinel = new \stdClass();
+    $originalVerbosity = $_ENV['SHELL_VERBOSITY'] ?? $emptySentinel;
     try {
         $_ENV['SHELL_VERBOSITY'] = 0;
         Artisan::call('tenants:migrate-fresh');
         $defaultOutput = Artisan::output();
     } finally {
-        $_ENV['SHELL_VERBOSITY'] = $originalVerbosity;
+        if ($originalVerbosity === $emptySentinel) {
+            unset($_ENV['SHELL_VERBOSITY']);
+        } else {
+            $_ENV['SHELL_VERBOSITY'] = $originalVerbosity;
+        }
     }
 
     Artisan::call('tenants:migrate-fresh -v');

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -368,17 +368,27 @@ test('migrate fresh command works', function () {
 
 test('migrate fresh command only shows migration output when run with the verbose option', function () {
     $tenant = Tenant::create();
+    $migratingOutput = 'Migrating tenant ' . $tenant->getTenantKey();
 
-    // pest()->artisan()->expectsOutput() cannot observe the output suppression,
-    // so use Artisan::call() + Artisan::output() instead.
+    // CI runs pest with -v, setting SHELL_VERBOSITY to 1, so in CI, the output is verbose by default
+    $shellVerbosity = getenv('SHELL_VERBOSITY');
+    $_ENV['SHELL_VERBOSITY'] = $_SERVER['SHELL_VERBOSITY'] = 0;
+    putenv('SHELL_VERBOSITY=0');
 
-    // By default the underlying tenants:migrate output is suppressed
-    Artisan::call('tenants:migrate-fresh');
-    expect(Artisan::output())->not()->toContain('Migrating tenant ' . $tenant->getTenantKey());
+    try {
+        Artisan::call('tenants:migrate-fresh');
+        $defaultOutput = Artisan::output();
 
-    // Underlying tenants:migrate output is shown when the verbose option is passed
-    Artisan::call('tenants:migrate-fresh -v');
-    expect(Artisan::output())->toContain('Migrating tenant ' . $tenant->getTenantKey());
+        Artisan::call('tenants:migrate-fresh -v');
+        $verboseOutput = Artisan::output();
+    } finally {
+        unset($_ENV['SHELL_VERBOSITY'], $_SERVER['SHELL_VERBOSITY']);
+        $shellVerbosity === false ? putenv('SHELL_VERBOSITY') : putenv("SHELL_VERBOSITY=$shellVerbosity");
+    }
+
+    // The output is silent by default and only shown with the verbose option
+    expect($defaultOutput)->not()->toContain($migratingOutput);
+    expect($verboseOutput)->toContain($migratingOutput);
 });
 
 test('migrate fresh command respects force option in production', function () {

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -366,6 +366,21 @@ test('migrate fresh command works', function () {
     expect(DB::table('users')->exists())->toBeFalse();
 });
 
+test('migrate fresh command only shows migration output when run with the verbose option', function () {
+    $tenant = Tenant::create();
+
+    // pest()->artisan()->expectsOutput() cannot observe the output suppression,
+    // so use Artisan::call() + Artisan::output() instead.
+
+    // By default the underlying tenants:migrate output is suppressed
+    Artisan::call('tenants:migrate-fresh');
+    expect(Artisan::output())->not()->toContain('Migrating tenant ' . $tenant->getTenantKey());
+
+    // Underlying tenants:migrate output is shown when the verbose option is passed
+    Artisan::call('tenants:migrate-fresh -v');
+    expect(Artisan::output())->toContain('Migrating tenant ' . $tenant->getTenantKey());
+});
+
 test('migrate fresh command respects force option in production', function () {
     // Set environment to production
     app()->detectEnvironment(fn() => 'production');

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -370,21 +370,21 @@ test('migrate fresh command only shows migration output when run with the verbos
     $tenant = Tenant::create();
     $migratingOutput = 'Migrating tenant ' . $tenant->getTenantKey();
 
-    // CI runs pest with -v, setting SHELL_VERBOSITY to 1, so in CI, the output is verbose by default
-    $shellVerbosity = getenv('SHELL_VERBOSITY');
-    $_ENV['SHELL_VERBOSITY'] = $_SERVER['SHELL_VERBOSITY'] = 0;
-    putenv('SHELL_VERBOSITY=0');
-
+    // CI runs pest with --verbose which makes Artisan::call() inherit the verbosity
+    // so we cannot easily test commands without -v. To work around that, we temporarily
+    // override $_ENV['SHELL_VERBOSITY'] immediately before executing the command. If this
+    // ever stops working, try also overriding the value in $_SERVER and putenv().
+    $originalVerbosity = $_ENV['SHELL_VERBOSITY'] ?? 0;
     try {
+        $_ENV['SHELL_VERBOSITY'] = 0;
         Artisan::call('tenants:migrate-fresh');
         $defaultOutput = Artisan::output();
-
-        Artisan::call('tenants:migrate-fresh -v');
-        $verboseOutput = Artisan::output();
     } finally {
-        unset($_ENV['SHELL_VERBOSITY'], $_SERVER['SHELL_VERBOSITY']);
-        $shellVerbosity === false ? putenv('SHELL_VERBOSITY') : putenv("SHELL_VERBOSITY=$shellVerbosity");
+        $_ENV['SHELL_VERBOSITY'] = $originalVerbosity;
     }
+
+    Artisan::call('tenants:migrate-fresh -v');
+    $verboseOutput = Artisan::output();
 
     // The output is silent by default and only shown with the verbose option
     expect($defaultOutput)->not()->toContain($migratingOutput);


### PR DESCRIPTION
Resubmission of #1369 (by @lordofthebrain), changes adapted to v4. Also added a test (passes with the MigrateFresh changes, fails without them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Improved `tenants:migrate-fresh` console output: per-tenant migration messages are now suppressed by default for a cleaner run.
  * When run with `-v`, per-tenant progress is shown, including the `Migrating tenant {tenantKey}` message.

* **Tests**
  * Added coverage to verify the command is silent by default and displays the `Migrating tenant {tenantKey}` message only when `-v` is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->