### PR TITLE
perf(rls): wrap current_setting() in the generated tenant policy for per-statement evaluation

### DIFF
--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -528,7 +528,7 @@ class TableRLSManager implements RLSPolicyManager
 
             if ($table === tenancy()->model()->getTable()) {
                 // Convert tenant key to text to match the session variable type
-                $query .= "{$column}::text = current_setting('{$sessionTenantKey}')\n";
+                $query .= "{$column}::text = (select current_setting('{$sessionTenantKey}'))\n";
                 continue;
             }
 

--- a/src/RLS/PolicyManagers/TraitRLSManager.php
+++ b/src/RLS/PolicyManagers/TraitRLSManager.php
@@ -67,7 +67,7 @@ class TraitRLSManager implements RLSPolicyManager
 
         return <<<SQL
         CREATE POLICY {$table}_rls_policy ON {$table} USING (
-            {$tenantKeyColumn}::text = current_setting('{$sessionTenantKey}')
+            {$tenantKeyColumn}::text = (select current_setting('{$sessionTenantKey}'))
         );
         SQL;
     }
@@ -87,7 +87,7 @@ class TraitRLSManager implements RLSPolicyManager
             {$parentRelationship->getForeignKeyName()} IN (
                 SELECT {$parent->getKeyName()}
                 FROM {$parent->getTable()}
-                WHERE {$tenantKeyColumn}::text = current_setting('{$sessionTenantKey}')
+                WHERE {$tenantKeyColumn}::text = (select current_setting('{$sessionTenantKey}'))
             )
         );
         SQL;

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -582,7 +582,7 @@ test('table rls manager generates queries correctly', function() {
     expect(array_values(app(TableRLSManager::class)->generateQueries()))->toEqualCanonicalizing([
         <<<SQL
         CREATE POLICY authors_rls_policy ON authors USING (
-            tenant_id::text = current_setting('my.current_tenant')
+            tenant_id::text = (select current_setting('my.current_tenant'))
         );
         SQL,
         <<<SQL
@@ -590,7 +590,7 @@ test('table rls manager generates queries correctly', function() {
             author_id IN (
                 SELECT id
                 FROM authors
-                WHERE tenant_id::text = current_setting('my.current_tenant')
+                WHERE tenant_id::text = (select current_setting('my.current_tenant'))
             )
         );
         SQL,
@@ -602,7 +602,7 @@ test('table rls manager generates queries correctly', function() {
                 WHERE author_id IN (
                     SELECT id
                     FROM authors
-                    WHERE tenant_id::text = current_setting('my.current_tenant')
+                    WHERE tenant_id::text = (select current_setting('my.current_tenant'))
                 )
             )
         );
@@ -652,7 +652,7 @@ test('table rls manager generates queries correctly', function() {
     expect(app(TableRLSManager::class)->generateQueries($paths))->toContain(
         <<<SQL
         CREATE POLICY primaries_rls_policy ON primaries USING (
-            tenant_id::text = current_setting('my.current_tenant')
+            tenant_id::text = (select current_setting('my.current_tenant'))
         );
         SQL,
         <<<SQL
@@ -660,7 +660,7 @@ test('table rls manager generates queries correctly', function() {
             primary_id IN (
                 SELECT id
                 FROM primaries
-                WHERE tenant_id::text = current_setting('my.current_tenant')
+                WHERE tenant_id::text = (select current_setting('my.current_tenant'))
             )
         );
         SQL,
@@ -672,7 +672,7 @@ test('table rls manager generates queries correctly', function() {
                 WHERE primary_id IN (
                     SELECT id
                     FROM primaries
-                    WHERE tenant_id::text = current_setting('my.current_tenant')
+                    WHERE tenant_id::text = (select current_setting('my.current_tenant'))
                 )
             )
         );

--- a/tests/RLS/TraitManagerTest.php
+++ b/tests/RLS/TraitManagerTest.php
@@ -279,7 +279,7 @@ test('trait rls manager generates queries correctly', function() {
     expect($manager->generateQueries())->toContain(
         <<<SQL
         CREATE POLICY posts_rls_policy ON posts USING (
-            tenant_id::text = current_setting('my.current_tenant')
+            tenant_id::text = (select current_setting('my.current_tenant'))
         );
         SQL,
         <<<SQL
@@ -287,7 +287,7 @@ test('trait rls manager generates queries correctly', function() {
             post_id IN (
                 SELECT id
                 FROM posts
-                WHERE tenant_id::text = current_setting('my.current_tenant')
+                WHERE tenant_id::text = (select current_setting('my.current_tenant'))
             )
         );
         SQL,


### PR DESCRIPTION
`archtechx/tenancy`'s RLS policy generator emits `current_setting('<tenant setting>')` **unwrapped** in the policy predicate. Postgres re-evaluates a bare `current_setting(...)` **once per row** the policy scans; wrapping it in a scalar subquery — `(select current_setting(...))` — makes it a per-statement InitPlan the planner evaluates once and caches. It's predicate-equivalent (tenant isolation unchanged) and the documented Postgres RLS performance pattern; the benefit grows with table size.

This wraps the generated call and keeps the test assertions in sync (`TraitRLSManager.php`, `TableRLSManager.php`, `TraitManagerTest.php`, `TableManagerTest.php`). I couldn't run the PHP / Laravel test suite locally — if CI surfaces another assertion on the generated policy SQL, point me at it and I'll update it.

Spotted with [pgrls](https://github.com/pgrls/pgrls) (an open-source Postgres RLS analyzer). Happy to adjust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant-aware access checks so generated database policies evaluate the current tenant value more reliably.
  * Updated policy behavior across direct and nested relationships to keep row-level security consistent in more query paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->