### PR TITLE
[4.x] Fix duplicate entry error when updating TenantPivot columns

### DIFF
--- a/src/ResourceSyncing/TriggerSyncingEvents.php
+++ b/src/ResourceSyncing/TriggerSyncingEvents.php
@@ -28,7 +28,8 @@ trait TriggerSyncingEvents
             $pivot->getCentralResourceAndTenant();
         });
 
-        static::saved(static function (self $pivot) {
+        // Only attach when the pivot is created
+        static::created(static function (self $pivot) {
             /**
              * @var static&Pivot $pivot
              * @var SyncMaster|null $centralResource

--- a/src/ResourceSyncing/TriggerSyncingEvents.php
+++ b/src/ResourceSyncing/TriggerSyncingEvents.php
@@ -22,9 +22,9 @@ trait TriggerSyncingEvents
     public static function bootTriggerSyncingEvents(): void
     {
         static::saving(static function (self $pivot) {
-            // Try getting the central resource to see if it is available
-            // If it is not available, throw an exception to interrupt the saving process
-            // And prevent creating a pivot record without a central resource
+            // Try getting the central resource to see if it is available.
+            // If it is not, getCentralResourceAndTenant() throws (indirectly, via findCentralResource() -> getResourceClass()),
+            // interrupting the save, preventing the creation of a pivot record without a central resource.
             $pivot->getCentralResourceAndTenant();
         });
 
@@ -56,6 +56,10 @@ trait TriggerSyncingEvents
         });
     }
 
+    /**
+     * @throws CentralResourceNotAvailableInPivotException Throws when the tenant is the pivot parent
+     * but the central resource class cannot be resolved (thrown indirectly via findCentralResource() -> getResourceClass())
+     */
     public function getCentralResourceAndTenant(): array
     {
         /** @var $this&Pivot $this */

--- a/tests/ResourceSyncingTest.php
+++ b/tests/ResourceSyncingTest.php
@@ -274,6 +274,32 @@ test('attaching central resources to tenants or vice versa creates synced tenant
     });
 });
 
+test('updating pivot column does not re-create the synced tenant resource', function () {
+    // Add an extra pivot column so we can update it
+    Schema::table('tenant_users', fn (Blueprint $table) => $table->string('note')->nullable());
+
+    $centralUser = CentralUser::create([
+        'global_id' => 'acme',
+        'name' => 'John Doe',
+        'email' => 'john@localhost',
+        'password' => 'secret',
+        'role' => 'commenter',
+    ]);
+
+    $tenant = Tenant::create();
+    migrateUsersTableForTenants();
+
+    // Attaching creates the tenant resource
+    $centralUser->tenants()->attach($tenant);
+    $tenant->run(fn () => expect(TenantUser::count())->toBe(1));
+
+    // Updating a pivot column does not re-attach and create the resource again
+    // (which would throw a duplicate entry error -- regression test for #1467)
+    $centralUser->tenants()->updateExistingPivot($tenant->getTenantKey(), ['note' => 'foo']);
+
+    $tenant->run(fn () => expect(TenantUser::count())->toBe(1));
+});
+
 test('detaching central users from tenants or vice versa force deletes the synced tenant resource', function (bool $attachUserToTenant) {
     $centralUser = CentralUser::create([
         'global_id' => 'acme',


### PR DESCRIPTION
`TriggerSyncingEvents` registered the pivot attach listener on `saved`, which fires on both inserts and updates. So updating pivot columns on a `TenantPivot` (e.g. via `updateExistingPivot()`) re-ran the attach flow and tried to create the tenant resource again, causing a duplicate entry error.

Switched the listener to `created` so we only attach when the pivot record is first created (detaching already uses `deleting`, so using `created` makes things a bit more consistent).

Added a regression test before the fix (https://github.com/archtechx/tenancy/pull/1469/commits/5e3eb4322cc487d540796317e813ac2ffe076646). The fix (https://github.com/archtechx/tenancy/pull/1469/commits/d2fb4bc0d524cd98ec680e973b791f475afc3548) then made the test pass.

Also improved the `saving` listener's comment a bit so that it's clear where the "central resource not available" exception actually comes from, since that wasn't obvious (also added the `@throws` annotation to `getCentralResourceAndTenant()`).

Closes #1467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate synced tenant resources when updating values on an existing pivot record.
  * Improved clarity around behavior when a central resource can’t be resolved, reducing the risk of creating invalid pivot records.
* **Tests**
  * Added a regression test ensuring updating pivot-only fields (without changing attachments) does not recreate or duplicate the synced tenant resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->