### PR TITLE
Fix: preserve custom onFail callback in UniversalRoutes::bootstrap()

### DIFF
--- a/src/Features/UniversalRoutes.php
+++ b/src/Features/UniversalRoutes.php
@@ -23,9 +23,16 @@ class UniversalRoutes implements Feature
     public function bootstrap(Tenancy $tenancy): void
     {
         foreach (static::$identificationMiddlewares as $middleware) {
-            $middleware::$onFail = function ($exception, $request, $next) {
+            // preserve any onFail callback set before universal routes bootstraps
+            $customOnFail = $middleware::$onFail;
+
+            $middleware::$onFail = function ($exception, $request, $next) use ($customOnFail) {
                 if (static::routeHasMiddleware($request->route(), static::$middlewareGroup)) {
                     return $next($request);
+                }
+
+                if ($customOnFail instanceof Closure) {
+                    return $customOnFail($exception, $request, $next);
                 }
 
                 throw $exception;

--- a/tests/UniversalRouteTest.php
+++ b/tests/UniversalRouteTest.php
@@ -88,6 +88,24 @@ class UniversalRouteTest extends TestCase
             ->assertSuccessful()
             ->assertSee('Tenancy is initialized.');
     }
+
+    #[Test]
+    public function universal_route_runs_custom_failed_initialization_override()
+    {
+        InitializeTenancyByDomain::$onFail = function () {
+            return 'custom failed logic.';
+        };
+
+        Route::middlewareGroup('universal', []);
+        config(['tenancy.features' => [UniversalRoutes::class]]);
+
+        Route::get('/foo', fn () => 'Tenant route')
+            ->middleware([InitializeTenancyByDomain::class]);
+
+        $this->get('http://acme.localhost/foo')
+            ->assertSuccessful()
+            ->assertSee('custom failed logic.');
+    }
 }
 
 class UniversalRouteController


### PR DESCRIPTION
Fixes #1470

This is a small, low-risk fix for the issue linked above, happy to adjust the approach if you'd prefer to solve it differently, but since the change is minimal and the impact felt high-value, I thought it was worth putting together as a starting point.

What this changes

UniversalRoutes::bootstrap() currently overwrites $onFail on both identification middlewares unconditionally, discarding any custom callback the application had set. This PR captures the existing callback before overwriting it, and falls back to it (instead of throwing) when the UniversalRoutes bypass check doesn't apply.

We've tested this against our own setup and confirmed it resolves the behaviour described in #1470. Open to feedback if you'd rather handle this differently (e.g. scoping it to v3 only given the v4/main split).