### PR TITLE
[4.x] Laravel 13.24 support (fix #1474)

### DIFF
--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -16,9 +16,7 @@ class Run extends Command
 
     protected $description = 'Run a command for tenant(s)';
 
-    protected $signature = 'tenants:run {commandname : The artisan command.}
-                            {--tenants=* : The tenant(s) to run the command for. Default: all}
-                            {--skip-tenants=* : The tenant(s) to skip}';
+    protected $signature = 'tenants:run {commandname : The artisan command.}';
 
     public function handle(): int
     {

--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -16,11 +16,21 @@ class Seed extends SeedCommand
 
     protected $description = 'Seed tenant database(s).';
 
-    protected $name = 'tenants:seed';
-
     public function __construct(ConnectionResolverInterface $resolver)
     {
-        parent::__construct($resolver);
+        // See https://github.com/archtechx/tenancy/issues/1474
+        if (version_compare(app()->version(), '13.24.0', '>=')) {
+            $this->signature = 'tenants:seed
+                    {class? : The class name of the root seeder}
+                    {--class=Database\\Seeders\\DatabaseSeeder : The class name of the root seeder}
+                    {--database= : The database connection to seed}
+                    {--force : Force the operation to run when in production}';
+            parent::__construct($resolver);
+            $this->specifyParameters();
+        } else {
+            $this->name = 'tenants:seed';
+            parent::__construct($resolver);
+        }
     }
 
     public function handle(): int

--- a/src/Concerns/HasTenantOptions.php
+++ b/src/Concerns/HasTenantOptions.php
@@ -55,9 +55,9 @@ trait HasTenantOptions
             });
     }
 
-    public function __construct()
+    public function __construct(mixed ...$args)
     {
-        parent::__construct();
+        parent::__construct(...$args);
 
         $this->specifyParameters();
     }

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -103,7 +103,7 @@ class TenancyServiceProvider extends ServiceProvider
                 $config['connection'] ??= $centralConnection;
 
                 /** @var CacheManager $this */
-                return $this->createDatabaseDriver($config); // @phpstan-ignore method.protected
+                return $this->createDatabaseDriver($config);
             });
 
             // DatabaseCacheBootstrapper explicitly writes 'tenant' into each store's 'connection'


### PR DESCRIPTION
- We conditionally use either $signature + specifyParameters() in the
  newer versions or just $name in the older versions. There doesn't
  appear to be a single solution that'd work in both versions, likely
  having to do with the constructor override in the trait and how the
  specifyParameters() method behaves differently in this class between
  versions
- Remove unnecessary options from the Run command (the trait adds those)
- Not directly related: make HasTenantOptions accept ...$args
- Unrelated: remove phpstan ignore in TenancyServiceProvider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tenant-related commands for compatibility with newer Laravel versions.
  * Simplified the `tenants:run` command interface by removing tenant selection options.
  * Preserved tenant selection behavior during command execution.
  * Improved command initialization across supported framework versions.
  * Ensured tenant option handling remains consistent when commands receive additional parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->