### PR TITLE
Fix tenants:seed command name

### DIFF
--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -20,10 +20,6 @@ class Seed extends SeedCommand
     {
         parent::__construct($resolver);
 
-        // Our --tenants/--skip-tenants/--with-pending options only get added automatically
-        // when the parent command isn't signature-based. Since Laravel 13.24, SeedCommand is,
-        // so we add them ourselves here -- checking first so we don't add them twice on older
-        // Laravel versions, where they're already there by this point.
         if (! $this->getDefinition()->hasOption('tenants')) {
             $this->specifyParameters();
         }
@@ -33,10 +29,6 @@ class Seed extends SeedCommand
     {
         parent::configure();
 
-        // We inherit SeedCommand's name ('db:seed') since we don't redeclare $name/$signature,
-        // so without this we'd overwrite Laravel's own db:seed command (see #1474). configure()
-        // always runs after the name is set, regardless of Laravel version, so setting it here
-        // is safe no matter which of $name/$signature the installed Laravel version uses.
         $this->setName('tenants:seed');
     }
 

--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -18,19 +18,26 @@ class Seed extends SeedCommand
 
     public function __construct(ConnectionResolverInterface $resolver)
     {
-        // See https://github.com/archtechx/tenancy/issues/1474
-        if (version_compare(app()->version(), '13.24.0', '>=')) {
-            $this->signature = 'tenants:seed
-                    {class? : The class name of the root seeder}
-                    {--class=Database\\Seeders\\DatabaseSeeder : The class name of the root seeder}
-                    {--database= : The database connection to seed}
-                    {--force : Force the operation to run when in production}';
-            parent::__construct($resolver);
+        parent::__construct($resolver);
+
+        // Our --tenants/--skip-tenants/--with-pending options only get added automatically
+        // when the parent command isn't signature-based. Since Laravel 13.24, SeedCommand is,
+        // so we add them ourselves here -- checking first so we don't add them twice on older
+        // Laravel versions, where they're already there by this point.
+        if (! $this->getDefinition()->hasOption('tenants')) {
             $this->specifyParameters();
-        } else {
-            $this->name = 'tenants:seed';
-            parent::__construct($resolver);
         }
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        // We inherit SeedCommand's name ('db:seed') since we don't redeclare $name/$signature,
+        // so without this we'd overwrite Laravel's own db:seed command (see #1474). configure()
+        // always runs after the name is set, regardless of Laravel version, so setting it here
+        // is safe no matter which of $name/$signature the installed Laravel version uses.
+        $this->setName('tenants:seed');
     }
 
     public function handle(): int

--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -20,6 +20,10 @@ class Seed extends SeedCommand
     {
         parent::__construct($resolver);
 
+        // Our --tenants/--skip-tenants/--with-pending options only get added automatically
+        // when the parent command isn't signature-based. Since Laravel 13.24, SeedCommand is,
+        // so we add them ourselves here -- checking first so we don't add them twice on older
+        // Laravel versions, where they're already there by this point.
         if (! $this->getDefinition()->hasOption('tenants')) {
             $this->specifyParameters();
         }
@@ -29,6 +33,10 @@ class Seed extends SeedCommand
     {
         parent::configure();
 
+        // We inherit SeedCommand's name ('db:seed') since we don't redeclare $name/$signature,
+        // so without this we'd overwrite Laravel's own db:seed command (see #1474). configure()
+        // always runs after the name is set, regardless of Laravel version, so setting it here
+        // is safe no matter which of $name/$signature the installed Laravel version uses.
         $this->setName('tenants:seed');
     }
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -16,7 +16,9 @@ use Stancl\Tenancy\Jobs\DeleteDatabase;
 use Illuminate\Database\DatabaseManager;
 use Stancl\Tenancy\Events\TenantCreated;
 use Stancl\Tenancy\Events\TenantDeleted;
+use Stancl\Tenancy\Commands\Seed;
 use Stancl\Tenancy\Tests\Etc\TestSeeder;
+use Illuminate\Database\Console\Seeds\SeedCommand;
 use Stancl\Tenancy\Events\DeletingTenant;
 use Stancl\Tenancy\Events\DatabaseMigrated;
 use Stancl\Tenancy\Tests\Etc\ExampleSeeder;
@@ -286,6 +288,16 @@ test('seed command works', function () {
         expect($user->count())->toBe(1)
             ->and($user->first()->email)->toBe('seeded@user');
     });
+});
+
+test('tenants:seed does not overwrite db:seed', function () {
+    $commands = Artisan::all();
+
+    expect($commands)->toHaveKey('db:seed')
+        ->and($commands)->toHaveKey('tenants:seed')
+        ->and($commands['db:seed'])->toBeInstanceOf(SeedCommand::class)
+        ->and($commands['db:seed'])->not()->toBeInstanceOf(Seed::class)
+        ->and($commands['tenants:seed'])->toBeInstanceOf(Seed::class);
 });
 
 test('database connection is switched to default after running commands', function (bool $initializeTenancy) {


### PR DESCRIPTION
Fixes #1474.

Replaces the `version_compare` check in `Seed::__construct()` with a `configure()` override that calls `setName('tenants:seed')`. `configure()` always runs after the command name is set by Symfony's `Command` constructor, regardless of whether the installed Laravel version's `SeedCommand` sets its name via `$name` (pre-13.24) or `$signature` (13.24+), so this works across versions without checking `app()->version()`.

`configure()` is also the general place to add, remove, or tweak a parent command's arguments/options (`$this->addArgument()`, `$this->addOption()`, or `$this->getDefinition()->remove*()`), since it's guaranteed to run after the parent's own definition is built and before the command executes. Worth keeping in mind for other commands here that extend Laravel's built-in ones and need to adjust their inherited signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tenant database seeding command registration so it no longer replaces Laravel’s built-in database seeding command.
  * Preserved separate access to both tenant seeding and standard database seeding commands.

* **Tests**
  * Added coverage confirming each seeding command resolves and operates independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->